### PR TITLE
cors 오류 수정

### DIFF
--- a/voc-kmac-main/src/main/java/kr/co/kmac/configuration/WebMvcConfig.java
+++ b/voc-kmac-main/src/main/java/kr/co/kmac/configuration/WebMvcConfig.java
@@ -3,6 +3,7 @@ package kr.co.kmac.configuration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -63,4 +64,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 ;
 
     }
+
+	@Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .maxAge(3600);
+	}
 }

--- a/voc-kmac-main/src/main/resources/application.yml
+++ b/voc-kmac-main/src/main/resources/application.yml
@@ -117,7 +117,8 @@ system:
 server:
   port: 8090
   #domain: http://api.vocservice.co.kr
-  domain: http://hvoc.co.kr:8090
+  #domain: http://hvoc.co.kr:8090
+  domain: http://voclab.co.kr:8090
 
 logging:
   pattern:


### PR DESCRIPTION
서비스 도메인 (www.voclab.co.kr) 과 API 도메인 (api.voclab.co.kr) 분리로 인해 cors 오류 수정